### PR TITLE
Remove libpmem2 (for now)

### DIFF
--- a/hello-pmdk/Makefile
+++ b/hello-pmdk/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -std=gnu99 -Wall -Wextra -O3
-EXE = hello-libpmem hello-libpmem2 hello-libpmemobj
-LDLIBS = -lpmem -lpmem2 -lpmemobj
+EXE = hello-libpmem hello-libpmemobj
+LDLIBS = -lpmem -lpmemobj
 
 all: $(EXE)
 

--- a/hello-pmdk/hello-libpmem.c
+++ b/hello-pmdk/hello-libpmem.c
@@ -5,5 +5,5 @@
 int main()
 {
   const char *msg = pmem_errormsg();
-  printf("Hello, pmem2_errormsg = [%s] (%ld) at %p\n", msg, strlen(msg), msg);
+  printf("Hello, pmem_errormsg = [%s] (%ld) at %p\n", msg, strlen(msg), msg);
 }


### PR DESCRIPTION
`libpmem2` is not available for CentOS.

```
[osalbahr@c64 ~]$ yum search libpmem2
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.umd.edu
 * centos-sclo-rh: atl.mirrors.clouvider.net
 * centos-sclo-sclo: mirrors.iu13.net
 * elrepo: reflector.westga.edu
 * epel: forksystems.mm.fcix.net
 * extras: atl.mirrors.clouvider.net
 * rpmfusion-free-updates: mirror.math.princeton.edu
 * updates: centosi8.centos.org
Warning: No matches found for: libpmem2
No matches found
[osalbahr@c64 ~]$ cat /etc/redhat-release
CentOS Linux release 7.9.2009 (Core)
[osalbahr@c64 ~]$ 
```

Closes #2 